### PR TITLE
fix yahoo finance url to make it work

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # バグ報告頂いてから２４時間以内に必ず直します。（という気概です）
 --------
 
-Yahoo!Japanファイナンス（http://finance.yahoo.co.jp/）
+Yahoo!Japanファイナンス ( http://finance.yahoo.co.jp/ )
 
 から株の情報をひっぱて適切なデータ型(Integer, Float, Range..). ごめんなさい、Yahoo!
 


### PR DESCRIPTION
どういう gem か確認するためにざっと見てたら README.md の Yahoo Finance の URL  が括弧も含まれてしまって、うまくサイトに飛べてなかったので、細かいけど修正しました。

あと、本格的な共同開発の経験がないので、いろいろ常識が抜けていると思うので、何か気になったらぜひ教えてください。branch の名前の付け方とか。
